### PR TITLE
Eligibility for WAYF is based only on entityID

### DIFF
--- a/Institutions.pm
+++ b/Institutions.pm
@@ -286,7 +286,7 @@ sub get_institution_list {
     my $ref_to_arr_of_hashref = $sth->fetchall_arrayref({});
 
     foreach my $ref ( @$ref_to_arr_of_hashref ) {
-        next unless ( defined $$ref{template} && defined $$ref{entityID} );
+        next unless ( defined $$ref{entityID} );
         __munge_template($ref);
     }
 


### PR DESCRIPTION
We no longer use the template for any other purpose, so there is no
reason to check that it is defined here. If something has an entityID,
it could show up in the WAYF; for production, that does not include
things with enabled=0.

No big rush to merge this. FWIW, it looks like `Institutions::get_institution_list` is called from mb (in `MBooks/PIFiller/ListUtils.pm`) as well as from wayf.