### PR TITLE
Refactor MdpConfig to use new add/override methods and allow ENV[key]

### DIFF
--- a/MdpConfig.pm
+++ b/MdpConfig.pm
@@ -30,11 +30,19 @@ use MdpConfig;
 my $config = new MdpConfig($primary_config_filename,
                            [$secondary_config_filename, $tertiary_config_filename]);
 
+# What do we have?
+
+if ($config->has("possible_key")) { ... }
+my $keys = $config->keys();
+
+# Get a value
+
 $config->get('db_hostname');
 
 # Need to override a value?
 
 $config->override('db_hostname', $ENV[DB_HOSTNAME]);
+$config->override_from_hashref(\%kv_pairs);
 
 =head1 METHODS
 

--- a/MdpConfig.pm
+++ b/MdpConfig.pm
@@ -32,6 +32,10 @@ my $config = new MdpConfig($primary_config_filename,
 
 $config->get('db_hostname');
 
+# Need to override a value?
+
+$config->override('db_hostname', $ENV[DB_HOSTNAME]);
+
 =head1 METHODS
 
 =over 8
@@ -45,58 +49,71 @@ use Config::Tiny;
 use Utils;
 use Debug::DUtils;
 
+
 sub new {
     my $package = shift;
     my $primary_config_filename = shift;
     my $secondary_config_filename = shift;
     my $tertiary_config_filename = shift;
 
-    ASSERT(-e "$primary_config_filename",
-           qq{"Could not find primary config file $primary_config_filename"});
-
-    my $config;
-
-    my $primary_config = $config = Config::Tiny->read($primary_config_filename);
-    ASSERT($primary_config, qq{Error in primary config file $primary_config_filename: } . Config::Tiny::errstr);
-
-    my $self = {};
-    $self->{'primary_config'} = $primary_config;
-    $self->{'primary_config_file'} = $primary_config_filename;
-
-    my $secondary_config;
-    if (defined($secondary_config_filename)) {
-        if (-e "$secondary_config_filename") {
-            $secondary_config = Config::Tiny->read($secondary_config_filename);
-            ASSERT($secondary_config, qq{Error in secondary config file $secondary_config_filename: } . Config::Tiny::errstr);
-            $self->{'secondary_config'} = $secondary_config;
-            $self->{'secondary_config_file'} = $secondary_config_filename;
-
-            foreach my $key (keys %{$secondary_config->{_}} ) {
-                $config->{_}{$key} = $secondary_config->{_}{$key};
-            }
-        }
-    }
-
-    my $tertiary_config;
-    if (defined($tertiary_config_filename)) {
-        if (-e "$tertiary_config_filename") {
-            $tertiary_config = Config::Tiny->read($tertiary_config_filename);
-            ASSERT($tertiary_config, qq{Error in tertiary config file $tertiary_config_filename: } . Config::Tiny::errstr);
-            $self->{'tertiary_config'} = $tertiary_config;
-            $self->{'tertiary_config_file'} = $tertiary_config_filename;
-
-            foreach my $key (keys %{$tertiary_config->{_}} ) {
-                $config->{_}{$key} = $tertiary_config->{_}{$key};
-            }
-        }
-    }
-
-    $self->{'config'} = $config;
+    my $self = { config => {} };
 
     bless($self, $package);
+
+    $self->{primary_config_file} = $primary_config_filename;
+    $self->add_config_from_file($primary_config_filename, 'primary_config');
+
+    if (defined($secondary_config_filename)) {
+        $self->{secondary_config_file} = $secondary_config_filename;
+        $self->add_config_from_file($secondary_config_filename, 'secondary_config');
+    }
+
+    if (defined($tertiary_config_filename)) {
+        $self->{tertiary_config_file} = $tertiary_config_filename;
+        $self->add_config_from_file($secondary_config_filename, 'tertiary_config');
+    }
+
     return $self;
+
 }
 
+# ---------------------------------------------------------------------
+
+=item add_config_from_file($config_file, $optional_config_key)
+
+Add configuration values from the given file, doing ENV[key] expansion.
+
+If the optional config_key is given, the Config::Tiny object resulting
+from loading that file will be stored in $self->{$optional_config_key}
+
+=cut
+
+# ---------------------------------------------------------------------
+
+sub add_config_from_file {
+    my $self = shift;
+    my $config_file = shift;
+    my $config_key = shift;
+
+    ASSERT(-e "$config_file",
+        qq{"Could not find  config file $config_file"});
+
+    my $config = Config::Tiny->read($config_file);
+    ASSERT($config, qq{Error in config file $config_file: } . Config::Tiny::errstr);
+
+    if (defined($config_key)) {
+        $self->{$config_key} = $config;
+    }
+    $self->merge_from_config_tiny($config);
+    $self->override_from_ENV($config_file);
+}
+
+
+sub merge_from_config_tiny {
+    my $self = shift;
+    my $ct = shift;
+    $self->override_from_hashref($ct->{_});
+}
 
 # ---------------------------------------------------------------------
 
@@ -111,21 +128,25 @@ sub merge {
     my $self = shift;
     my $M_config = shift;
 
-    ASSERT((ref $M_config eq 'MdpConfig'), qq{"Invalid atgument});
+    my $mtype = ref $M_config;
 
-    foreach my $key (keys %{$M_config->{'config'}{_}} ) {
+    ASSERT(($mtype eq 'MdpConfig'), qq{"Invalid argument: MdpConfig merge given '$mtype' instead of MdpConfig object"});
+
+
+    foreach my $key (CORE::keys %{$M_config->{'config'}{_}}) {
         # Do not overwrite any key value in the main config that came
         # from a tertiary config file.  Those are (typically)
         # debugging values that would be stomped by defaults from the
         # to-be-merged-in M_config
-        if ( defined $self->{'tertiary_config'}->{_}{$key} ) {
-            if ( $self->{'tertiary_config'}->{_}{$key} ne $M_config->{'config'}->{_}{$key} ) {
+        if (defined $self->{'tertiary_config'}->{_}{$key}) {
+            if ($self->{'tertiary_config'}->{_}{$key} ne $M_config->{'config'}->{_}{$key}) {
                 next;
             }
         }
-            
+
         $self->{'config'}->{_}{$key} = $M_config->{'config'}->{_}{$key};
     }
+
 }
 
 # ---------------------------------------------------------------------
@@ -150,6 +171,101 @@ sub get {
         return $val;
     }
 }
+
+
+# ---------------------------------------------------------------------
+
+=item keys
+
+Get all the keys. MdpConfig doesn't allow any hierarchy at all,
+so, it's all top-level
+
+=cut
+
+
+# ---------------------------------------------------------------------
+
+sub keys {
+    my $self = shift;
+    return CORE::keys(%{$self->{'config'}->{_}});
+}
+
+
+# ---------------------------------------------------------------------
+
+=item override($key, $val)
+
+Set (and thus override) a configuation parameter
+
+=cut
+
+# ---------------------------------------------------------------------
+
+sub override {
+    my $self = shift;
+    my $key = shift;
+    my $value = shift;
+
+    my $config = $self->{'config'};
+    $config->{_}{$key} = $value;
+    return $value;
+}
+
+
+# ---------------------------------------------------------------------
+
+=item override_from_hashref($hashref)
+
+Set (and thus potentially overrides) key/value pairs from the given hashref
+
+=cut
+
+# ---------------------------------------------------------------------
+
+sub override_from_hashref {
+    my $self = shift;
+    my $hr = shift;
+
+    foreach my $key (CORE::keys %$hr) {
+        $self->override($key, $hr->{$key});
+    }
+}
+
+
+# ---------------------------------------------------------------------
+
+=item override_from_ENV
+
+Any value of the form ENV[keyname] will be overwritten with the
+corresponding environment variable.
+
+If the environment variable is unset, throw a warning and move on.
+
+=cut
+
+# ---------------------------------------------------------------------
+
+sub override_from_ENV {
+    my $self = shift;
+    my $filename = shift;
+
+    $filename || ($filename = "<unknown>");
+
+    foreach my $key ($self->keys()) {
+        my $val = $self->get($key);
+        if ($val =~ /ENV\[["']?(.+?)["']?\]/) {
+            my $env_var = $1;
+            my $env_val = $ENV{$env_var};
+            if ($env_val) {
+                $self->override($key, $env_val);
+            }
+            else {
+                warn("Config $filename references ENV[$env_var] which is unset");
+            }
+        }
+    }
+}
+
 
 # ---------------------------------------------------------------------
 
@@ -189,25 +305,25 @@ sub __config_debug {
     my $tertiary_config = $self->{'tertiary_config'};
 
     DEBUG('all,conf',
-          sub {
-              my $s;
+        sub {
+            my $s;
 
-              $s .= q{primary config file=} . $self->{'primary_config_file'} . qq{<br/>\n};
-              $s .= q{secondary config file=} . $self->{'secondary_config_file'} . qq{<br/>\n};
-              $s .= q{tertiary config file=} . $self->{'tertiary_config_file'} . qq{<br/>\n};
+            $s .= q{primary config file=} . $self->{'primary_config_file'} . qq{<br/>\n};
+            $s .= q{secondary config file=} . $self->{'secondary_config_file'} . qq{<br/>\n};
+            $s .= q{tertiary config file=} . $self->{'tertiary_config_file'} . qq{<br/>\n};
 
-              foreach my $key (sort keys %{$config->{_}} ) {
-                  my $res = $config->{_}{$key};
+            foreach my $key (sort CORE::keys %{$config->{_}}) {
+                my $res = $config->{_}{$key};
 
-                  my $pri = $primary_config->{_}{$key};
-                  my $sec = $secondary_config->{_}{$key} if ($secondary_config);
-                  my $ter = $tertiary_config->{_}{$key} if ($tertiary_config);
+                my $pri = $primary_config->{_}{$key};
+                my $sec = $secondary_config->{_}{$key} if ($secondary_config);
+                my $ter = $tertiary_config->{_}{$key} if ($tertiary_config);
 
-                  my $from = (defined($ter) ? 'tertiary' : (defined($sec) ? 'secondary' : 'primary'));
-                  $s .= qq{$key = $res from $from config<br/>\n}
-              }
-              return $s;
-          });
+                my $from = (defined($ter) ? 'tertiary' : (defined($sec) ? 'secondary' : 'primary'));
+                $s .= qq{$key = $res from $from config<br/>\n}
+            }
+            return $s;
+        });
 }
 
 __END__
@@ -219,7 +335,7 @@ Modified: Phillip Farber, University of Michigan, pfarber@umich.edu
 
 =head1 COPYRIGHT
 
-Copyright 2007-2010 ©, The Regents of The University of Michigan, All Rights Reserved
+Copyright 2007-2010 Â©, The Regents of The University of Michigan, All Rights Reserved
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
A refactoring which preserves the previous structure
(including only allowing three config files) but adds
a number of methods:

  * `add_config_from_file($filename)` When configuration
    is added from a file, ENV[key] will be replaced by
    the value of that environment variable, or throw
    a warning if $ENV{key} is unset.
  * `keys` to get the keys
  * `override($key, $value)` to manually add a value
  * `override_from_hashref({key => $value})` to override
    with many key-value pairs at once

The initialization routine itself calls `add_config_from_file`,
so ENV replacement happens when calling `new`, too.

Note that the original `merge($other_MpdConfig)` does NOT
do ENV replacement.

It would have been better to make this MpdConfig all the way
down (instead of passing around Config::Tiny object) but
I didn't know if anything was digging into these objects
elsewhere.