### PR TITLE
HT-3189 - add user_has_total_access check

### DIFF
--- a/Access/Rights.pm
+++ b/Access/Rights.pm
@@ -1240,6 +1240,9 @@ sub _determine_access_type {
         # e.g. users with role=crms
         $access_type = $RightsGlobals::HT_TOTAL_USER;
     }
+    elsif ( $auth->user_has_total_access($C) ) {
+        $access_type = $RightsGlobals::HT_TOTAL_USER;
+    }
     elsif ($auth->user_is_print_disabled_proxy($C)) {
         $access_type = $RightsGlobals::SSD_PROXY_USER;
     }

--- a/Auth/Auth.pm
+++ b/Auth/Auth.pm
@@ -72,6 +72,7 @@ use warnings;
 
 use File::Basename;
 use XML::LibXML;
+use List::Util qw(first);
 
 use Utils;
 use Debug::DUtils;
@@ -81,6 +82,8 @@ use Auth::Exclusive;
 use Institutions;
 
 use Context;
+
+use Utils::Settings;
 
 use constant COSIGN => 'cosign';
 use constant SHIBBOLETH => 'shibboleth';
@@ -102,6 +105,8 @@ $$NON_HT_AFFILIATED_ENTITY_IDS{'pumex-idp'} = 1;
 # for print disabled status
 my $ENTITLEMENT_VALID_AFFILIATIONS_REGEXP =
   qr,^(member|faculty|staff|student)$,ios;
+
+our $SWITCHABLE_ROLES = Utils::Settings::load( 'mdp-lib', 'switches', 1 );
 
 sub new {
     my $class = shift;
@@ -1042,6 +1047,7 @@ Description
 sub user_is_print_disabled_proxy {
     my $self = shift;
     my $C = shift;
+    my $check_possible = shift;
 
     # ACL test
     my $is_proxy = Auth::ACL::a_Authorized( {role => 'ssdproxy'} );
@@ -1051,9 +1057,11 @@ sub user_is_print_disabled_proxy {
         $is_proxy = ($entitlement eq 'ssdproxy');
     }
 
+    return $is_proxy if ( $check_possible );
+
     if ( $is_proxy ) {
         # check that the user has toggled this setting
-        my $activated = $C->get_object('Session')->get_persistent('activated_role') eq 'ssdproxy';
+        my $activated = $C->get_object('Session')->get_persistent('activated_role') eq 'enhancedTextProxy';
         unless ( $activated ) { $is_proxy = 0; }
     }
 
@@ -1086,6 +1094,29 @@ sub user_is_print_disabled {
     }
 
     return $is_disabled;
+}
+
+sub user_has_total_access {
+    my $self = shift;
+    my $C    = shift;
+    my $check_possible = shift;
+
+    # ACL test
+    my $has_total_access =
+      Auth::ACL::a_Authorized( { access => 'total' }, 'unmasked' );
+
+    return $has_total_access if ( $check_possible );
+
+    if ($has_total_access) {
+
+        # check that the user has toggled this setting
+        my $activated_role =
+          $C->get_object('Session')->get_persistent('activated_role');
+        my $activated = defined $activated_role && $activated_role eq 'totalAccess';
+        unless ($activated) { $has_total_access = 0; }
+    }
+
+    return $has_total_access;
 }
 
 # ---------------------------------------------------------------------
@@ -1172,6 +1203,28 @@ sub get_eduPersonTargetedID {
     $targeted_id = $ENV{persistent_id} if ( defined $ENV{persistent_id} );
     $targeted_id = $ENV{'persistent-id'} if ( defined $ENV{'persistent-id'} );
     return ( split(/;/, $targeted_id) )[0] || '';
+}
+
+# ---------------------------------------------------------------------
+# ---------------------------------------------------------------------
+sub get_switchable_roles {
+    my $self = shift;
+    my $C = shift;
+
+    return grep { 
+        my $method = $$_{method}; 
+        $self->$method($C, 1) 
+    } @$SWITCHABLE_ROLES;
+}
+
+sub get_activated_switchable_role {
+    my $self = shift;
+    my $C = shift;
+
+    return first { 
+        my $method = $$_{method}; 
+        $self->$method($C); 
+    } $self->get_switchable_roles($C);
 }
 
 # ---------------------------------------------------------------------

--- a/Auth/Auth.pm
+++ b/Auth/Auth.pm
@@ -1211,9 +1211,13 @@ sub get_switchable_roles {
     my $self = shift;
     my $C = shift;
 
+    my $check_possible = 1;
+
     return grep { 
-        my $method = $$_{method}; 
-        $self->$method($C, 1) 
+        if ( $$_{enabled} || defined $ENV{HT_DEV} ) {
+            my $method = $$_{method}; 
+            $self->$method( $C, $check_possible );
+        }
     } @$SWITCHABLE_ROLES;
 }
 
@@ -1222,8 +1226,10 @@ sub get_activated_switchable_role {
     my $C = shift;
 
     return first { 
-        my $method = $$_{method}; 
-        $self->$method($C); 
+        if ( $$_{enabled} || defined $ENV{HT_DEV} ) {
+            my $method = $$_{method}; 
+            $self->$method($C); 
+        }
     } $self->get_switchable_roles($C);
 }
 

--- a/Utils/Settings.pm
+++ b/Utils/Settings.pm
@@ -4,7 +4,7 @@ use JSON::XS;
 use Carp;
 
 sub load {
-    my ( $app, $specific ) = @_;
+    my ( $app, $specific, $wantarray ) = @_;
 
     my $settings_base = $app;
     $settings_base .= "/$specific" if ( $specific );
@@ -34,7 +34,7 @@ sub load {
     }
 
     # NOOP
-    return {};
+    return $wantarray ? [] : {};
 }
 
 1;

--- a/t/access_ht_total_user_switched.t
+++ b/t/access_ht_total_user_switched.t
@@ -1,0 +1,238 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use File::Spec;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use RightsGlobals;
+
+use MdpConfig;
+use Auth::Auth;
+use Auth::ACL;
+use Access::Rights;
+use Database;
+use Institutions;
+use CGI;
+use Utils;
+
+use Test::File;
+
+use Data::Dumper;
+use feature qw(say);
+
+#---- MONEKYPATCHES
+no warnings 'redefine';
+
+{
+
+    package Session;
+
+    sub new {
+        my $class = shift;
+        return bless {}, $class;
+    }
+
+    sub get_persistent {
+        my ( $self, $key ) = @_;
+        return $$self{$key};
+    }
+
+    sub set_persistent {
+        my ( $self, $key, $value ) = @_;
+        $$self{$key} = $value;
+    }
+
+}
+
+
+local *Auth::Auth::affiliation_is_hathitrust = sub {
+    return 1;
+};
+
+local *Auth::Auth::auth_sys_is_SHIBBOLETH = sub {
+    return 1;
+};
+
+local *Auth::ACL::S___total_access_using_DEBUG_super = sub {
+    return 0;
+};
+
+local *Auth::ACL::a_Authorized = sub {
+    my $access_ref = shift;
+    return ( defined $$access_ref{access} && $$access_ref{access} eq 'total' );
+};
+
+local *Auth::Auth::affiliation_has_emergency_access = sub {
+return 0;
+};
+
+#---- MONEKYPATCHES
+
+my $C   = new Context;
+my $cgi = new CGI;
+$C->set_object( 'CGI', $cgi );
+my $config = new MdpConfig(
+    File::Spec->catdir( $ENV{SDRROOT}, 'mdp-lib/Config/uber.conf' ),
+    File::Spec->catdir( $ENV{SDRROOT}, 'slip-lib/Config/common.conf' )
+);
+$C->set_object( 'MdpConfig', $config );
+
+my $db_user = $ENV{'MARIADB_USER'} || 'ht_testing';
+my $db      = new Database($db_user);
+$C->set_object( 'Database', $db );
+
+my $auth = Auth::Auth->new($C);
+$C->set_object( 'Auth', $auth );
+
+my $sess = Session->new($C);
+$C->set_object('Session', $sess);
+
+mock_institutions($C);
+mock_acls($C);
+
+local %ENV = %ENV;
+$ENV{HTTP_HOST}   = q{babel.hathitrust.org};
+$ENV{SERVER_ADDR} = q{141.213.128.185};
+$ENV{SERVER_PORT} = q{443};
+$ENV{AUTH_TYPE}   = q{shibboleth};
+$ENV{affiliation} = q{member@umich.edu};
+
+sub setup_us_institution {
+    $ENV{REMOTE_USER}            = 'user@umich.edu';
+    $ENV{eppn}                   = q{user@umich.edu};
+    $ENV{umichCosignFactor}      = q{UMICH.EDU};
+    $ENV{Shib_Identity_Provider} = Auth::Auth::get_umich_IdP_entity_id();
+}
+
+sub setup_nonus_instition {
+    $ENV{REMOTE_USER} = 'user@ox.ac.edu';
+    $ENV{eppn}        = q{user@ox.ac.edu};
+    delete $ENV{umichCosignFactor};
+    $ENV{Shib_Identity_Provider} = q{https://registry.shibboleth.ox.ac.uk/idp};
+    $ENV{affiliation}            = q{member@ox.ac.edu};
+    $ENV{entitlement} = q{http://www.hathitrust.org/access/enhancedText};
+}
+
+sub test_attr {
+    my ( $attr, $access_profile, $location ) = @_;
+    my $id = "test.$attr\_$access_profile";
+    $ENV{TEST_GEO_IP_COUNTRY_CODE} = $location || 'US';
+
+    unless ($attr) {
+        print STDERR caller();
+    }
+
+    my $ar     = Access::Rights->new( $C, $id );
+    my $status = $ar->check_final_access_status( $C, $id );
+    return $status;
+}
+
+my $num_tests = 0;
+
+my $tests =
+  Test::File::load_data("$FindBin::Bin/data/access/ht_total_user.tsv");
+
+my $ht_affiliate_tests =
+  Test::File::load_data("$FindBin::Bin/data/access/ht_affiliate.tsv");
+
+my $ht_affiliate_expected = {};
+foreach my $test (@$ht_affiliate_tests) {
+    my (
+        $code,                     $attr,
+        $access_profile,           $access_type,
+        $expected_volume,          $expected_download_page,
+        $expected_download_volume, $expected_download_plaintext
+    ) = @$test;
+
+    my $location = $access_type =~ m,NONUS, ? 'NONUS' : 'US';
+    $$ht_affiliate_expected{$attr,$access_profile,$location} = $expected_volume;
+}
+
+# first pass, test that the unswitched user is denied
+foreach my $test (@$tests) {
+    my (
+        $code,                     $attr,
+        $access_profile,           $access_type,
+        $expected_volume,          $expected_download_page,
+        $expected_download_volume, $expected_download_plaintext
+    ) = @$test;
+
+    my $location = $access_type =~ m,NONUS, ? 'NONUS' : 'US';
+
+    next if ( $$ht_affiliate_expected{$attr,$access_profile,$location} =~ m,allow, );
+    next if ( $expected_volume eq 'deny' );
+
+    if   ( $location eq 'US' ) { setup_us_institution(); }
+    else                       { setup_nonus_instition(); }
+
+    is(
+        test_attr( $attr, $access_profile, $location ),
+        'deny',
+"ht_total_user + attr=$attr + location=$location + profile=$access_profile"
+    );
+    $num_tests += 1;
+}
+
+# activate switch
+$sess->set_persistent('activated_role', 'totalAccess');
+
+# second pass, should be ht_total_user
+foreach my $test (@$tests) {
+    my (
+        $code,                     $attr,
+        $access_profile,           $access_type,
+        $expected_volume,          $expected_download_page,
+        $expected_download_volume, $expected_download_plaintext
+    ) = @$test;
+
+    my $location = $access_type =~ m,NONUS, ? 'NONUS' : 'US';
+
+    if   ( $location eq 'US' ) { setup_us_institution(); }
+    else                       { setup_nonus_instition(); }
+
+    is(
+        test_attr( $attr, $access_profile, $location ),
+        $expected_volume,
+"ht_total_user + attr=$attr + location=$location + profile=$access_profile"
+    );
+    $num_tests += 1;
+}
+
+done_testing($num_tests);
+
+#---- UTILITY
+sub mock_institutions {
+    my ($C) = @_;
+
+    my $inst_ref = { entityIDs => {} };
+    $$inst_ref{entityIDs}{ Auth::Auth::get_umich_IdP_entity_id() } = {
+        sdrinst              => 'uom',
+        inst_id              => 'umich',
+        entityID             => Auth::Auth::get_umich_IdP_entity_id(),
+        enabled              => 1,
+        allowed_affiliations => q{^(alum|member)@umich.edu},
+        us                   => 1,
+    };
+    bless $inst_ref, 'Institutions';
+    $C->set_object( 'Institutions', $inst_ref );
+}
+
+sub mock_acls {
+    my ($C) = @_;
+
+    my $acl_ref = {};
+    $$acl_ref{'user@umich.edu'} = {
+        userid   => 'user@umich.edu',
+        role     => 'corrections',
+        usertype => 'staff',
+        access   => 'total',
+        expires  => '2040-12-31 23:59:59'
+    };
+    bless $acl_ref, 'Auth::ACL';
+    $C->set_object( 'Auth::ACL', $acl_ref );
+}
+


### PR DESCRIPTION
- implement `Auth::Auth::user_has_total_access`, similar to `Auth::Auth::user_is_print_disabled_proxy`
- add `user_has_total_access` check to `Access::Rights::_determine_access_type`
- updated `Auth::Auth::user_is_print_disabled_proxy` and `Auth::Auth::user_has_total_access` to take a second parameter that causes the method to return true if the user has the possibility of this being true
- update `handle_USER_AFFILIATION_PI` and `handle_USER_HAS_ROLE_TOGGLES_PI` in `mdp-lib/PIFiller/Common/USER_NAME.pm`
- switches will be loaded from `$ENV{SDRROOT}/etc/settings/mdp-lib/switches.json`, which have the format 

```
[
  {
    "method": "user_is_print_disabled_proxy",
    "role": "enhancedTextProxy",
    "label": "ATRS"
  }
]
```