### PR TITLE
HT-3190 - new debug option for CRMS

### DIFF
--- a/Access/Rights.pm
+++ b/Access/Rights.pm
@@ -1235,6 +1235,12 @@ sub _determine_access_type {
     elsif (DEBUG('ssd', 'SSD access forced') ) {
         $access_type = $RightsGlobals::SSD_USER;
     }
+    elsif (Auth::ACL::S___total_access_using_DEBUG_supercalifragilisticexpialidocious) {
+
+        # access=total user with access enabled via debug=supercalifragilisticexpialidocious,
+        # e.g. users with role=crms
+        $access_type = $RightsGlobals::HT_TOTAL_USER;
+    }
     elsif (Auth::ACL::S___total_access_using_DEBUG_super) {
         # access=total user with access enabled via debug=super,
         # e.g. users with role=crms

--- a/Auth/ACL.pm
+++ b/Auth/ACL.pm
@@ -295,6 +295,27 @@ sub S___total_access_using_DEBUG_super {
 
 # ---------------------------------------------------------------------
 
+=item S___total_access_using_DEBUG_supercalifragilisticexpialidocious
+
+This predicate allows a user with access=total and using
+DEBUG('supercalifragilisticexpialidocious') to gain access 
+restricted materials while not being
+able to alter attribute values returned from
+__get_user_attributes(). Typically CRMS users, among others.
+
+=cut
+
+# ---------------------------------------------------------------------
+sub S___total_access_using_DEBUG_supercalifragilisticexpialidocious {
+    __load_access_control_list();
+
+    my $total = DEBUG('super')
+      && __a_Authorized_core( { access => 'total' }, 'unmasked' );
+    return $total;
+}
+
+# ---------------------------------------------------------------------
+
 =item S___superuser_role
 
 This predicate allows a user with role=superuser to:

--- a/Auth/ACL.pm
+++ b/Auth/ACL.pm
@@ -301,7 +301,7 @@ This predicate allows a user with access=total and using
 DEBUG('supercalifragilisticexpialidocious') to gain access 
 restricted materials while not being
 able to alter attribute values returned from
-__get_user_attributes(). Typically CRMS users, among others.
+__get_user_attributes(). Intended for CRMS users.
 
 =cut
 
@@ -309,7 +309,7 @@ __get_user_attributes(). Typically CRMS users, among others.
 sub S___total_access_using_DEBUG_supercalifragilisticexpialidocious {
     __load_access_control_list();
 
-    my $total = DEBUG('super')
+    my $total = DEBUG('supercalifragilisticexpialidocious')
       && __a_Authorized_core( { access => 'total' }, 'unmasked' );
     return $total;
 }


### PR DESCRIPTION
Because I was curious if we'd get a cease-and-desist: https://www.merriam-webster.com/words-at-play/origin-supercalifragilisticexpialidocious

Adds a precocious `debug` option to (eventually) replace `debug=super`.