### PR TITLE
DEV-307  + DEV-308 - support contributor_name and transferring collections

### DIFF
--- a/Config/uber.conf
+++ b/Config/uber.conf
@@ -21,6 +21,7 @@ delete_check_max_item_ids      = 10000
 coll_table_name                = mb_collection
 item_table_name                = mb_item
 coll_item_table_name           = mb_coll_item
+transfer_table_name            = mb_transfer
 coll_table_display_field_names = MColl_ID|collname|owner|owner_name|description|num_items|shared
 item_table_display_field_names = display_title|author|date|bib_id|book_id
 item_table_sort_field_names    = sort_title|sort_author|sort_date


### PR DESCRIPTION
- support fetching/editing `contributor_name`
- ensure that incoming metadata values are plaintext
- add `transfer_collection` to transfer owner 