### PR TITLE
DEV-385 - encode sanitized user input

### DIFF
--- a/Collection.pm
+++ b/Collection.pm
@@ -862,7 +862,7 @@ sub _edit_metadata {
         eval {
             $value = HTML::Entities::decode_entities($value);
             my $html_dom = $html_parser->parse_html_string("<div>$value</div>", { recover => 2 });
-            $value = $html_dom->textContent;
+            $value = HTML::Entities::encode_entities($html_dom->textContent);
         };
         if ( my $err = $@ ) {
             ASSERT($err, qq{Value could be not sanitized $coll_id : $value : $user});

--- a/t/lib/Test/ACL.pm
+++ b/t/lib/Test/ACL.pm
@@ -1,0 +1,20 @@
+package Test::ACL;
+
+sub mock_acls {
+    my ( $C, $acl_data ) = @_;
+
+    if ( ref($acl_data) eq 'HASH' ) {
+        $acl_data = [ $acl_data ];
+    }
+
+    my $acl_ref = {};
+    foreach my $acl_datum ( @$acl_data ) {
+        my $key = join('|', $$acl_datum{userid}, $$acl_datum{identity_provider});
+        $$acl_ref{$key} = $acl_datum;
+    }
+
+    bless $acl_ref, 'Auth::ACL';
+    $C->set_object('Auth::ACL', $acl_ref);
+}
+
+1;


### PR DESCRIPTION
TL,DR:

```
$value = HTML::Entities::decode_entities($value);
my $html_dom = $html_parser->parse_html_string("<div>$value</div>", { recover => 2 });
$value = HTML::Entities::encode_entities($html_dom->textContent);
```

`$html_dom->textContent` emits naked ampersands, which break when this content is inserted into an XML (string). Wrapping with `encode_entities` will make the sanitized input safe.
