### PR TITLE
TTO-21 - handle multiple values in eppn

### DIFF
--- a/CollectionSet.pm
+++ b/CollectionSet.pm
@@ -493,7 +493,7 @@ sub list_colls
 
     $statement = qq{$SELECT $FROM $WHERE $ORDER $LIMIT;};
 
-    DEBUG('dbcoll', qq{sql statement="$statement"});
+    DEBUG('dbcoll', qq{sql statement="$statement" params="@params"});
 
     my $dbh = $self->{'dbh'};
     my $sth = DbUtils::prep_n_execute($dbh, $statement, @params);

--- a/Utils.pm
+++ b/Utils.pm
@@ -105,8 +105,10 @@ sub Get_Legacy_Remote_User {
 
 sub Get_Remote_User_Names {
     my @usernames = ( Get_Remote_User() );
-    if ( defined $ENV{eppn} && $ENV{eppn} && lc $ENV{eppn} ne $usernames[0] ) {
-        push @usernames, lc $ENV{eppn};
+    if ( defined $ENV{eppn} && $ENV{eppn} ) {
+        foreach my $value ( split(/;/, lc $ENV{eppn} ) ) {
+            push @usernames, $value unless ( grep(/^$value$/, @usernames) );
+        }
     }
     return @usernames;
 }

--- a/t/get_remote_user.t
+++ b/t/get_remote_user.t
@@ -1,0 +1,47 @@
+#!/usr/bin/perl
+
+use feature qw(say);
+
+use strict;
+use warnings;
+use Test::More;
+use File::Spec;
+
+use Identifier;
+use Utils;
+use Auth::Auth;
+
+use File::Basename qw(dirname);
+use FindBin;
+
+my $C = new Context;
+my $cgi = new CGI;
+$C->set_object('CGI', $cgi);
+my $config = new MdpConfig(File::Spec->catdir($ENV{SDRROOT}, 'mdp-lib/Config/uber.conf'),
+                           File::Spec->catdir($ENV{SDRROOT}, 'slip-lib/Config/common.conf'));                           
+$C->set_object('MdpConfig', $config);
+
+
+my $auth = Auth::Auth->new($C);
+$C->set_object( 'Auth', $auth );
+
+local %ENV = %ENV;
+
+# simple test
+$ENV{REMOTE_USER} = q{urn:test.edu:user:alpha};
+is(Utils::Get_Remote_User(), $ENV{REMOTE_USER}, "matches REMOTE_USER");
+
+$ENV{REMOTE_USER} = q{urn:test.edu:user:BETA};
+is(Utils::Get_Remote_User(), lc $ENV{REMOTE_USER}, "matches lc REMOTE_USER");
+
+$ENV{REMOTE_USER} = q{urn:test.edu:user:gamma};
+$ENV{eppn} = q{gamma@test.edu};
+my $user_names_1 = [ lc $ENV{REMOTE_USER}, 'gamma@test.edu' ];
+is_deeply([ Utils::Get_Remote_User_Names() ], $user_names_1, "returns all user names");
+
+$ENV{REMOTE_USER} = q{urn:test.edu:user:delta};
+$ENV{eppn} = q{delta@test.edu;delta@test.edu;delta@lib.test.edu};
+my $user_names_2 = [ lc $ENV{REMOTE_USER}, 'delta@test.edu', 'delta@lib.test.edu' ];
+is_deeply([ Utils::Get_Remote_User_Names() ], $user_names_2, "returns all unique user names");
+
+done_testing();


### PR DESCRIPTION
Account for the possibility of multiple values in `eppn`.

Added `t/get_user_names.t` to be able to test the logic locally.