### PR TITLE
DEV-682 - extensions for firebird

### DIFF
--- a/Access/Rights.pm
+++ b/Access/Rights.pm
@@ -1426,7 +1426,7 @@ sub _resolve_access_by_GeoIP {
     my $required_location = shift;
 
     return 'allow' if ( ! defined $ENV{REMOTE_ADDR} && ! defined $ENV{HTTP_HOST} );
-    return 'allow' if ( $ENV{FORCE_GEOIP} eq 'US' );
+    return 'allow' if ( defined $ENV{FORCE_GEOIP} && $ENV{FORCE_GEOIP} eq 'US' );
 
     require Utils::GeoIP;
 

--- a/Access/Rights.pm
+++ b/Access/Rights.pm
@@ -1426,6 +1426,7 @@ sub _resolve_access_by_GeoIP {
     my $required_location = shift;
 
     return 'allow' if ( ! defined $ENV{REMOTE_ADDR} && ! defined $ENV{HTTP_HOST} );
+    return 'allow' if ( $ENV{FORCE_GEOIP} eq 'US' );
 
     require Utils::GeoIP;
 

--- a/CollectionSet.pm
+++ b/CollectionSet.pm
@@ -82,6 +82,13 @@ use DbUtils;
 use MdpConfig;
 use Debug::DUtils;
 
+our %COLLTYPES = (
+    all => 1,
+    all_colls => 1,
+    'my-collections' => 1,
+    featured => 1,
+    updated => 1
+);
 
 sub new
 {
@@ -504,6 +511,29 @@ sub list_colls
     return $array_ref;
 }
 
+sub count_colls
+{
+    my $self = shift;
+    my ( $coll_type, $sortkey, $direction, $slice_start, $recs_per_slice ) = @_;
+
+    my $coll_table_name          = $self->get_coll_table_name;
+    
+    my $statement = '';
+    my $SELECT = qq{SELECT COUNT(MColl_ID) };
+    my $FROM = qq{FROM $coll_table_name};
+    my ($WHERE, @params) = $self->_get_where($coll_type);
+    $statement = qq{$SELECT $FROM $WHERE;};
+
+    my $dbh       = $self->{'dbh'};
+    my $sth       = DbUtils::prep_n_execute( $dbh, $statement, @params );
+    my $array_ref = $sth->fetchrow_arrayref();
+
+    $sth->finish;
+
+    return $$array_ref[0];
+
+}
+
 # ---------------------------------------------------------------------
 
 =item _get_where
@@ -524,24 +554,34 @@ sub _get_where
 
     my ( $owner_names, $owner_expr ) = $self->_get_owner_expr($user);
 
-    ASSERT(($coll_type eq 'my_colls') || ( $coll_type eq 'my-collections') || ($coll_type eq 'pub_colls') || ($coll_type eq 'all_colls') || ($coll_type eq 'featured_colls'),
-           qq{CollectionSet::list_colls(coll_type) is $coll_type.  Should be my_colls or pub_colls});
+    # ASSERT(($coll_type eq 'my_colls') || ( $coll_type eq 'my-collections') || ($coll_type eq 'updated') || ($coll_type eq 'all_colls') || ($coll_type eq 'featured'),
+    #        qq{CollectionSet::list_colls(coll_type) is $coll_type.  Should be my_colls or pub_colls});
+    ASSERT(exists($COLLTYPES{$coll_type}), qq{CollectionSet::list_colls(coll_type) is $coll_type});
 
 
     if ($coll_type eq "pub_colls")
     {
         $where .= qq{shared = 1};
     }
-    elsif ($coll_type eq "all_colls")
+    elsif ($coll_type eq "all_colls" || $coll_type eq 'all')
     {
         # $where .= qq{(shared = 1 AND num_items > 0) OR (owner = ?)};
         # push @params, $user_id;
         push @params, @$owner_names;
         $where .= qq{( shared = 1 AND num_items > 0 ) OR ( owner IN ($owner_expr) )};
     }
-    elsif ($coll_type eq "featured_colls")
+    elsif ($coll_type eq "featured")
     {
         $where .= qq{(shared = 1 AND num_items > 0 AND (featured IS NOT NULL OR featured != ''))};
+    }
+    elsif ($coll_type eq "updated")
+    {
+        require Date::Manip::Date;
+        my $updated_limit_date = new Date::Manip::Date;
+        $updated_limit_date->parse("30 days ago");
+        my $updated_limit = $updated_limit_date->printf("%Y-%m-%d %H:%M:%S");
+        push @params, @$owner_names, $updated_limit;
+        $where .= qq{( shared = 1 AND num_items > 0 ) OR ( owner IN ($owner_expr) ) AND (modified >= ?)};
     }
     else
     {

--- a/CollectionSet.pm
+++ b/CollectionSet.pm
@@ -567,12 +567,12 @@ sub _get_where
     {
         # $where .= qq{(shared = 1 AND num_items > 0) OR (owner = ?)};
         # push @params, $user_id;
-        # push @params, @$owner_names;
-        # $where .= qq{( shared = 1 AND num_items > 0 ) OR ( owner IN ($owner_expr) )};
+        push @params, @$owner_names;
+        $where .= qq{( shared = 1 AND num_items > 0 ) OR ( owner IN ($owner_expr) )};
 
         ## 2023-05-15 - with 8K collections AND hiding the owner name, nobody is
         ## going to navigate to their collections with all_colls
-        $where .= qq{shared = 1 AND num_items > 0};
+        # $where .= qq{shared = 1 AND num_items > 0};
 
     }
     elsif ($coll_type eq "featured")

--- a/CollectionSet.pm
+++ b/CollectionSet.pm
@@ -567,8 +567,13 @@ sub _get_where
     {
         # $where .= qq{(shared = 1 AND num_items > 0) OR (owner = ?)};
         # push @params, $user_id;
-        push @params, @$owner_names;
-        $where .= qq{( shared = 1 AND num_items > 0 ) OR ( owner IN ($owner_expr) )};
+        # push @params, @$owner_names;
+        # $where .= qq{( shared = 1 AND num_items > 0 ) OR ( owner IN ($owner_expr) )};
+
+        ## 2023-05-15 - with 8K collections AND hiding the owner name, nobody is
+        ## going to navigate to their collections with all_colls
+        $where .= qq{shared = 1 AND num_items > 0};
+
     }
     elsif ($coll_type eq "featured")
     {

--- a/Institutions.pm
+++ b/Institutions.pm
@@ -308,6 +308,7 @@ sub get_idp_list {
     my $results = [];
 
     my $inst = $C->get_object('Auth')->get_institution_code($C) || 'notaninstitution';
+    my %seen = ();
 
     foreach my $hash_ref ( sort { $a->{name} cmp $b->{name} } @$list_ref ) {
         my $add_to_list = 0;
@@ -325,6 +326,8 @@ sub get_idp_list {
             $add_to_list = 0;
         }
         next unless ($add_to_list);
+        next if ( $seen{$$hash_ref{inst_id}});
+        $seen{$$hash_ref{inst_id}} = 1;
 
         my $host = $ENV{'HTTP_HOST'} || 'localhost';
         my $idp_url = $hash_ref->{template};

--- a/MarcMetadata.pm
+++ b/MarcMetadata.pm
@@ -516,6 +516,30 @@ sub get_publisher {
     return ($unescape ? __xml_unescape($self->{_publisher}) : $self->{_publisher});
 }
 
+sub get_description
+{
+    my $self = shift;
+    my $unescape = shift;
+
+    return '' if ($self->{_metadatafailure});
+    return ($unescape ? __xml_unescape($self->{_description}) : $self->{_description}) if (defined $self->{_description});
+
+    my $root = $self->__get_document_root;
+    return '' unless($root);
+
+    my @tmp = ();
+    foreach my $subfield ( qw(a b c) ) {
+        my $text = $root->findvalue(qq{normalize-space(//datafield[\@tag='300']/subfield[\@code='$subfield'])});
+        push @tmp, $text if ( $text );
+    }
+
+    my $description = join(' ', @tmp);
+    $description =~ s,\s+, ,gsm;
+    $self->{_description} = $description;
+
+    return ($unescape ? __xml_unescape($self->{_description}) : $self->{_description});   
+}
+
 sub get_catalog_record_no
 {
     my $self = shift;

--- a/MarcMetadata.pm
+++ b/MarcMetadata.pm
@@ -516,6 +516,18 @@ sub get_publisher {
     return ($unescape ? __xml_unescape($self->{_publisher}) : $self->{_publisher});
 }
 
+sub get_catalog_record_no
+{
+    my $self = shift;
+    return '' if ($self->{_metadatafailure});
+
+    my $root = $self->__get_document_root;
+    return '' unless($root);
+
+    my ($value) = $root->findvalue(qq{normalize-space(//controlfield[\@tag='001'])});
+    return $value;
+}
+
 # ---------------------------------------------------------------------
 
 =item __xml_unescape

--- a/PIFiller/Common/Globals.pm
+++ b/PIFiller/Common/Globals.pm
@@ -19,6 +19,7 @@ BEGIN
 
 =cut
 use Encode;
+use JSON::XS;
 
 use Utils;
 use Debug::DUtils;
@@ -515,6 +516,30 @@ sub handle_CACHE_TIMESTAMP_PI
     }
     
     return qq{<Timestamp href="$href" modtime="$modtime" />};
+}
+
+sub handle_COMMON_ASSETS_PI
+    : PI_handler(COMMON_ASSETS)
+{
+    my ($C, $act, $piParamHashRef) = @_;
+
+    # default to netlify
+    my $stylesheet_link = q{//hathitrust-firebird-common.netlify.app/assets/index.css};
+    my $script_link = q{//hathitrust-firebird-common.netlify.app/assets/index.js};
+
+    my $path = q{/common/firebird};
+    my $manifest_filename = qq{$ENV{SDRROOT}/firebird-common/dist/manifest.json};
+    if ( -f $manifest_filename ) {
+        my $manifest_raw = Utils::read_file($manifest_filename);
+        my $manifest_data = JSON::XS::decode_json($$manifest_raw);
+        $stylesheet_link = $path . '/dist/' . $$manifest_data{'index.css'}{'file'};
+        $script_link = $path . '/dist/' . $$manifest_data{'index.html'}{'file'};
+    }
+
+    return <<XML;
+<Script path="$path">$script_link</Script>
+<Stylesheet path="$path">$stylesheet_link</Stylesheet>
+XML
 }
 
 

--- a/Utils.pm
+++ b/Utils.pm
@@ -274,6 +274,7 @@ sub get_cookie_domain
     my $cgi = shift;
 
     my $virtual_host = HTTP_hostname();
+    return 'localhost' if ( $virtual_host =~ m,^localhost,);
 
     my ($cookie_domain) = ($virtual_host =~ m,^.*(\..+?\..+?)$,);
     if (! $cookie_domain)

--- a/View/Fallback.pm
+++ b/View/Fallback.pm
@@ -65,6 +65,7 @@ my %g_skin_map =
      'crms'      => '/pt/web/crms',
      'crmsworld' => '/pt/web/crms',
      '2021'      => '/pt/web/2021',
+     'firebird'  => '<alicorn',
     );
 
 # Map internal coll_ids to a permanent collection name '0000000000' is
@@ -173,7 +174,16 @@ sub get_fallback_path
     my $skin_path = $g_skin_map{$skin_name};
     if ($skin_path)
     {
-        @fallback_path = ($skin_path, @fallback_path);
+        if ( $skin_path =~ m,^<, ) {
+            $skin_path = substr($skin_path, 1);
+            foreach (@fallback_path) {
+                s/$skin_path/$skin_name/g;
+            }
+        } else {
+            my $app_name = $C->get_object('App')->get_app_name;
+            $skin_path =~ s,<app>,$app_name,;
+            @fallback_path = ( $skin_path, @fallback_path );
+        }
     }
     
     return \@fallback_path;

--- a/View/Fallback.pm
+++ b/View/Fallback.pm
@@ -62,6 +62,7 @@ use Debug::DUtils;
 my %g_skin_map =
     (
      'default'   => '',
+     'alicorn'   => '',
      'crms'      => '/pt/web/crms',
      'crmsworld' => '/pt/web/crms',
      '2021'      => '/pt/web/2021',
@@ -160,7 +161,11 @@ sub get_fallback_path
 
     # Skin
     my $skin = new View::Skin($C);
-    my $skin_name = $skin->get_skin_name($C) || 'firebird';
+    my $skin_name = $skin->get_skin_name($C);
+    $skin_name = 'firebird' if ( $skin_name eq 'default' ); #  && $ENV{HOST_NAME} eq 'preview.babel.hathitrust.org' );
+    $skin_name = 'default' if ( $skin_name eq 'alicorn' );
+
+    print STDERR "AHOY AHOY $skin_name\n";
 
     # Local configuration
     my $config = $C->get_object('MdpConfig');

--- a/View/Fallback.pm
+++ b/View/Fallback.pm
@@ -59,14 +59,16 @@ use Debug::DUtils;
 # increases. 
 
 # NOTE: Skin name constants must agree with values in Skin.pm
+# skin values that start with `<` are treated as regexs to apply
+# against the application's default skin paths
 my %g_skin_map =
     (
      'default'   => '',
-     'alicorn'   => '',
+     'alicorn'   => '<firebird',
+     '2021'      => '<firebird',
      'crms'      => '/pt/web/crms',
      'crmsworld' => '/pt/web/crms',
-     '2021'      => '/pt/web/2021',
-     'firebird'  => '<alicorn|2021',
+     'firebird'  => '',
     );
 
 # Map internal coll_ids to a permanent collection name '0000000000' is
@@ -162,8 +164,15 @@ sub get_fallback_path
     # Skin
     my $skin = new View::Skin($C);
     my $skin_name = $skin->get_skin_name($C);
-    $skin_name = 'firebird' if ( $skin_name eq 'default' ); #  && $ENV{HOST_NAME} eq 'preview.babel.hathitrust.org' );
-    $skin_name = 'default' if ( $skin_name eq 'alicorn' );
+
+    ## force 2021 -> alicorn
+    $skin_name = 'alicorn' if ( $skin_name eq '2021' );
+
+    ## -- if (heaven forbid) you find yourself needing to build a 
+    ## -- new theme, uncomment these to change defaults before
+    ## -- updating all the global.conf configurations
+    # $skin_name = 'firebird' if ( $skin_name eq 'default' );
+    # $skin_name = 'default' if ( $skin_name eq 'alicorn' );
 
     # Local configuration
     my $config = $C->get_object('MdpConfig');

--- a/View/Fallback.pm
+++ b/View/Fallback.pm
@@ -66,7 +66,7 @@ my %g_skin_map =
      'crms'      => '/pt/web/crms',
      'crmsworld' => '/pt/web/crms',
      '2021'      => '/pt/web/2021',
-     'firebird'  => '<alicorn',
+     'firebird'  => '<alicorn|2021',
     );
 
 # Map internal coll_ids to a permanent collection name '0000000000' is
@@ -164,8 +164,6 @@ sub get_fallback_path
     my $skin_name = $skin->get_skin_name($C);
     $skin_name = 'firebird' if ( $skin_name eq 'default' ); #  && $ENV{HOST_NAME} eq 'preview.babel.hathitrust.org' );
     $skin_name = 'default' if ( $skin_name eq 'alicorn' );
-
-    print STDERR "AHOY AHOY $skin_name\n";
 
     # Local configuration
     my $config = $C->get_object('MdpConfig');

--- a/View/Fallback.pm
+++ b/View/Fallback.pm
@@ -160,7 +160,7 @@ sub get_fallback_path
 
     # Skin
     my $skin = new View::Skin($C);
-    my $skin_name = $skin->get_skin_name($C);
+    my $skin_name = $skin->get_skin_name($C) || 'firebird';
 
     # Local configuration
     my $config = $C->get_object('MdpConfig');

--- a/bin/debug.pl
+++ b/bin/debug.pl
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+
+use feature qw(say);
+use Config::Tiny;
+use Data::Dumper;
+use Getopt::Long;
+
+my @ALL_APPS = qw/ls mb ping ssd pt imgsrv/;
+
+sub usage {
+    say "# enable/disable debug=local/enabled;\n# by default all installed apps will be configured.";
+    say "$0 --enable [app app+]";
+    say "$0 --disable [app app+]";
+    exit;
+}
+
+my $enabled;
+GetOptions(
+    'enable!' => \$enabled,
+    'disable' => sub { $enabled = 0 }
+);
+
+unless ( defined $enabled ) {
+    usage();
+    exit;
+}
+
+my @apps = scalar @ARGV ?  @ARGV : @ALL_APPS;
+
+foreach my $app ( @apps ) {
+    my $app_dir = qq{$ENV{SDRROOT}/$app};
+    next unless ( -d $app_dir );
+    my $local_filename = qq{$app_dir/lib/Config/local.conf};
+    my $config = ( -f $local_filename ) ?
+        Config::Tiny->read($local_filename) : 
+        Config::Tiny->new;
+    $$config{_}{debug_local} = $enabled;
+    $$config{_}{debug_enabled} = $enabled;
+
+    # this is dumb, but internally mdp-lib
+    # depends on "key = value" to have that whitespace
+    my @output = ();
+    foreach my $line ( split(/\n/, $config->write_string()) ) {
+        my ( $key, $value ) = split(/=/, $line, 2);
+        push @output, qq{$key = $value};
+    }
+    open(my $fh, ">", $local_filename) || die "could not open $local_filename - $!";
+    print $fh join("\n", @output);
+    close($fh);
+    say "updated $app: debug=$enabled";
+}


### PR DESCRIPTION
`CollectionSet.pm`: updated to support `a=listcs` doing server-side rendering of the collection list, vs. a single-page app.

`PIFiller/Common/Globals.pm`: load firebird assets from the `manifest.json` that's constructed on build.

`View/Fallback.pm`: define `firebird` skin, and define `alicorn` for older browsers (if necessary).

`bin/debug.pl` - sets `debug=local` on `babel-local-dev` environments