### PR TITLE
TTO-153 Logged-in user doesn't see collections despite matching username

### DIFF
--- a/Utils.pm
+++ b/Utils.pm
@@ -104,15 +104,17 @@ sub Get_Legacy_Remote_User {
 }
 
 # Returns an array of unique (Get_Remote_User, case-preserving REMOTE_USER if it exists,
-# EPPN components in case-preserving and lowercase-only forms)
+# EPPN components in case-preserving and lowercase-only forms).
+# Note: returns the empty string when user is not logged in, i.e., returns ('')
 sub Get_Remote_User_Names {
     my @usernames = ( Get_Remote_User() );
     if ( exists $ENV{REMOTE_USER} && defined $ENV{REMOTE_USER} && $ENV{REMOTE_USER} ) {
-        $value = $ENV{REMOTE_USER};
+        my $value = $ENV{REMOTE_USER};
         push @usernames, $value unless grep(/^$value$/, @usernames);
     }
     if ( defined $ENV{eppn} && $ENV{eppn} ) {
         foreach my $value ( split(/;/, $ENV{eppn} ) ) {
+            next unless $value;
             push @usernames, $value unless ( grep(/^$value$/, @usernames) );
             $value = lc $value;
             push @usernames, $value unless ( grep(/^$value$/, @usernames) );

--- a/Utils.pm
+++ b/Utils.pm
@@ -103,10 +103,18 @@ sub Get_Legacy_Remote_User {
     return $remote_user;
 }
 
+# Returns an array of unique (Get_Remote_User, case-preserving REMOTE_USER if it exists,
+# EPPN components in case-preserving and lowercase-only forms)
 sub Get_Remote_User_Names {
     my @usernames = ( Get_Remote_User() );
+    if ( exists $ENV{REMOTE_USER} && defined $ENV{REMOTE_USER} && $ENV{REMOTE_USER} ) {
+        $value = $ENV{REMOTE_USER};
+        push @usernames, $value unless grep(/^$value$/, @usernames);
+    }
     if ( defined $ENV{eppn} && $ENV{eppn} ) {
-        foreach my $value ( split(/;/, lc $ENV{eppn} ) ) {
+        foreach my $value ( split(/;/, $ENV{eppn} ) ) {
+            push @usernames, $value unless ( grep(/^$value$/, @usernames) );
+            $value = lc $value;
             push @usernames, $value unless ( grep(/^$value$/, @usernames) );
         }
     }

--- a/t/Utils.t
+++ b/t/Utils.t
@@ -11,20 +11,25 @@ local %ENV = %ENV;
 subtest "Get_Remote_User_Names" => sub {
   my $save_remote_user = $ENV{REMOTE_USER};
   my $save_eppn = $ENV{eppn};
-  $ENV{eppn} = 'EPPN@default.invalid';
-  $ENV{REMOTE_USER} = 'REMOTE_USER@default.invalid';
-  subtest "contains lowercase REMOTE_USER" => sub {
-    ok(1 <= scalar grep(/remote_user/, Utils::Get_Remote_User_Names()));
+
+  subtest "with logged-in user" => sub {
+    $ENV{eppn} = 'EPPN@default.invalid';
+    $ENV{REMOTE_USER} = 'REMOTE_USER@default.invalid';
+    my @names = Utils::Get_Remote_User_Names();
+    ok(1 <= scalar grep(/remote_user/, @names), "contains lowercase REMOTE_USER");
+    ok(1 <= scalar grep(/REMOTE_USER/, @names), "contains case-preserved REMOTE_USER");
+    ok(1 <= scalar grep(/eppn/, @names), "contains lowercase EPPN");
+    ok(1 <= scalar grep(/EPPN/, @names), "contains case-preserved EPPN");
   };
-  subtest "contains case-preserved REMOTE_USER" => sub {
-    ok(1 <= scalar grep(/REMOTE_USER/, Utils::Get_Remote_User_Names()));
+
+  subtest "with logged-out user" => sub {
+    delete $ENV{REMOTE_USER};
+    delete $ENV{eppn};
+    my @names = Utils::Get_Remote_User_Names();
+    ok(1 == scalar @names, "there is one name");
+    ok('' eq $names[0], "name is empty string");
   };
-  subtest "contains lowercase EPPN" => sub {
-    ok(1 <= scalar grep(/eppn/, Utils::Get_Remote_User_Names()));
-  };
-  subtest "contains case-preserved EPPN" => sub {
-    ok(1 <= scalar grep(/EPPN/, Utils::Get_Remote_User_Names()));
-  };
+
   $ENV{REMOTE_USER} = $save_remote_user;
   $ENV{eppn} = $save_eppn;
 };

--- a/t/Utils.t
+++ b/t/Utils.t
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+
+use Utils;
+
+local %ENV = %ENV;
+
+subtest "Get_Remote_User_Names" => sub {
+  my $save_remote_user = $ENV{REMOTE_USER};
+  my $save_eppn = $ENV{eppn};
+  $ENV{eppn} = 'EPPN@default.invalid';
+  $ENV{REMOTE_USER} = 'REMOTE_USER@default.invalid';
+  subtest "contains lowercase REMOTE_USER" => sub {
+    ok(1 <= scalar grep(/remote_user/, Utils::Get_Remote_User_Names()));
+  };
+  subtest "contains case-preserved REMOTE_USER" => sub {
+    ok(1 <= scalar grep(/REMOTE_USER/, Utils::Get_Remote_User_Names()));
+  };
+  subtest "contains lowercase EPPN" => sub {
+    ok(1 <= scalar grep(/eppn/, Utils::Get_Remote_User_Names()));
+  };
+  subtest "contains case-preserved EPPN" => sub {
+    ok(1 <= scalar grep(/EPPN/, Utils::Get_Remote_User_Names()));
+  };
+  $ENV{REMOTE_USER} = $save_remote_user;
+  $ENV{eppn} = $save_eppn;
+};
+
+done_testing();


### PR DESCRIPTION
- `Utils::Get_Remote_User_Names` modified to include case-preserved `REMOTE_USER` and `eppn` components.
- Additional tests for logged-in and not-logged-in cases added. (Existing tests are in `t/get_remote_user.t`)