### PR TITLE
TTO-172 Process METS gbs:scanID along with gbs:ownerID

### DIFF
--- a/MdpItem.pm
+++ b/MdpItem.pm
@@ -1530,6 +1530,9 @@ sub ProcessOwnerIds {
                     foreach my $ownerid_el ( $techmd_el->findnodes(qq{.//gbs:ownerID}) ) {
                         push @tmp, $ownerid_el->textContent;
                     }
+                    foreach my $scanid_el ( $techmd_el->findnodes(qq{.//gbs:scanID}) ) {
+                        push @tmp, $scanid_el->textContent;
+                    }
                     $$techmd_ownerid_map{$id} = [ sort @tmp ];
                 }
 


### PR DESCRIPTION
- Add gbs:scanID fields to the ownerID-to-seq map in the same way as gbs:ownerID fields are.
- Will follow up with an attempt to understand these fields and make sure we are using them in a way that won't get us into trouble.