### PR TITLE
DEV-1076: Record statistics for operations imgsrv might do

### DIFF
--- a/MdpItem.pm
+++ b/MdpItem.pm
@@ -291,6 +291,9 @@ sub GetMdpItem {
     }
 
     my $delta = Time::HiRes::time() - $time0;
+    if(my $metrics = $C->{Metrics}) {
+      $metrics->observe("mdpitem_get_mdpitem_seconds",$delta, { cache => $cache_status });
+    }
     Utils::Logger::__Log_benchmark($C, 
         [["id", $id],["delta",$delta],["label","GetMdpItem"],["cache",$cache_status]], 'mdpitem');
 

--- a/MdpItem.pm
+++ b/MdpItem.pm
@@ -292,6 +292,7 @@ sub GetMdpItem {
 
     my $delta = Time::HiRes::time() - $time0;
     if(my $metrics = $C->{Metrics}) {
+      $mdpItem->{_metrics} = $C->{Metrics};
       $metrics->observe("mdpitem_get_mdpitem_seconds",$delta, { cache => $cache_status });
     }
     Utils::Logger::__Log_benchmark($C, 
@@ -1837,6 +1838,7 @@ sub GetDirPathMaybeExtract {
                  $fileSystemLocation,
                  $pattern_arr_ref,
                  $exclude_pattern_arr_ref,
+                 $self->{_metrics}
                 );
     }
     else
@@ -1891,7 +1893,9 @@ sub GetFilePathMaybeExtract {
                  $self->GetId(),
                  $fileSystemLocation,
                  $fileName,
-                 $suffix
+                 $suffix,
+                 undef,
+                 $self->{_metrics}
                 );
     }
     else

--- a/Utils/Extract.pm
+++ b/Utils/Extract.pm
@@ -23,12 +23,12 @@ use strict;
 
 use Utils;
 use Utils::Logger;
+use Utils::MonitorRun;
 use Identifier;
 use Debug::DUtils;
 use Utils::Logger;
 
 # Perl
-use IPC::Run;
 use Time::HiRes qw();
 use File::Basename qw(basename dirname);
 
@@ -195,6 +195,7 @@ sub extract_file_to_temp_cache {
     my $filename = shift;
     my $suffix = shift;
     my $input_cache_dir = shift;
+    my $metrics = shift;
 
     my $stripped_pairtree_id = Identifier::get_pairtree_id_wo_namespace($id);
     my $zip_file = $file_sys_location . qq{/$stripped_pairtree_id.zip};
@@ -203,7 +204,10 @@ sub extract_file_to_temp_cache {
     my @unzip;
     push @unzip, $UNZIP_PROG, "-j", "-qq", "-d", $input_cache_dir, $zip_file, "$stripped_pairtree_id/$filename";
 
-    __run($id, \@unzip, "$input_cache_dir/$filename");
+    __run(id => $id, 
+      unzip => \@unzip, 
+      test_filename => "$input_cache_dir/$filename", 
+      metrics => $metrics);
 
     return
       (-e qq{$input_cache_dir/$filename})
@@ -238,7 +242,7 @@ sub extract_filelist_to_temp_cache {
     # -j: just filenames, not full paths, -qq: very quiet
     push @unzip, $UNZIP_PROG, "-j", "-qq", "-d", $input_cache_dir, $zip_file, @filenames;
 
-    __run($id, \@unzip);
+    __run(id => $id, unzip => \@unzip);
 
     return $input_cache_dir;
 }
@@ -288,6 +292,7 @@ sub extract_dir_to_temp_cache {
     my $file_sys_location = shift;
     my $patterns_arr_ref = shift;
     my $exclude_patterns_arr_ref = shift;
+    my $metrics = shift;
 
     my $stripped_pairtree_id = Identifier::get_pairtree_id_wo_namespace($id);
     my $zip_file = $file_sys_location . qq{/$stripped_pairtree_id.zip};
@@ -302,15 +307,17 @@ sub extract_dir_to_temp_cache {
         push @unzip, "-x", @$exclude_patterns_arr_ref;
     }
 
-    __run($id, \@unzip);
+    __run(id => $id, unzip => \@unzip, metrics => $metrics);
 
     return $input_cache_dir;
 }
 
 sub __run {
-    my $id = shift;
-    my $unzip = shift;
-    my $test_filename = shift;
+    my %params = @_;
+    my $id = $params{id};
+    my $unzip = $params{unzip};
+    my $test_filename = $params{test_filename};
+    my $metrics = $params{metrics};
 
     my $error_file = Utils::get_tmp_logdir() . '/extract-error';
 
@@ -320,7 +327,7 @@ sub __run {
 
     my $stderr;
     my $time0 = Time::HiRes::time();
-    IPC::Run::run \@yes, '|',  $unzip, ">", "/dev/null", "2>>", \$stderr;
+    my $run_stats = Utils::MonitorRun::run_with_stats( \@yes, '|',  $unzip, ">", "/dev/null", "2>>", \$stderr);
     my $system_retval = $? >> 8;
 
     my $cmd = join(' ', @$unzip);
@@ -341,7 +348,17 @@ sub __run {
     __extract_report($system_retval, $error_file, $cmd);
 
     my $delta = Time::HiRes::time() - $time0;
+    # TODO: Add io stats to __Log_benchmark output?
     Utils::Logger::__Log_benchmark(undef, [["id", $id],["delta",$delta],["label","__run"],["cmd",$cmd]], 'extract');
+
+    if($metrics and $test_filename) {
+      $metrics->observe("utils_extract_run_seconds",$delta);
+      # TODO add extracted size when extracting more than one file?
+      $metrics->add("utils_extract_extracted_size_bytes",(-s $test_filename));
+      while (my ($k, $v) = each %$run_stats) {
+        $metrics->add("utils_extract_io_stats_$k",$v);
+      }
+    }
 }
 
 1;

--- a/Utils/MonitorRun.pm
+++ b/Utils/MonitorRun.pm
@@ -1,0 +1,96 @@
+package Utils::MonitorRun;
+
+=head1 NAME
+
+Utils::MonitorRun
+
+=head1 DESCRIPTION
+
+Run a subprocess with IPC::Run and extract/report statistics as it runs and
+as it exits.
+
+=head1 SYNOPSIS
+
+Utils::MonitorRun::run_with_stats(...)
+
+This takes the same arguments as IPC::Run::run, but will periodically dump
+stats about the process.
+
+=head1 METHODS
+
+=over 8
+
+=cut
+
+use strict;
+use parent qw(IPC::Run);
+use POSIX;
+
+sub dumpstats {
+  my $self = shift;
+
+  my $total_utime;
+  my $total_stime;
+
+  foreach my $kid (@{$self->{KIDS}}) {
+    my $pid = $kid->{PID};
+
+    # don't clobber exit status in the calling context
+    local $?;
+    if (-e "/proc/$pid/stat") {
+      open(my $statfh, "<", "/proc/$pid/stat") or warn("Can't open /proc/$pid/stat $!");
+      # see proc(5) (man 5 proc) for field definitions
+      my @fields = split(' ',<$statfh>);
+      my $status = $fields[2];
+      # only want to gather further stats if the process has just exited and we
+      # need to wait for it
+      next unless $status eq 'Z' and !$kid->{gotstats};
+
+      my $clock_ticks = POSIX::sysconf( &POSIX::_SC_CLK_TCK );
+      my $utime = $fields[13] / $clock_ticks;
+      my $stime = $fields[14] / $clock_ticks;
+      $self->{stats}{utime} += $utime;
+      $self->{stats}{stime} += $stime;
+
+      my $iostats = `sudo -n /usr/local/bin/catprocio $pid`;
+      if($iostats) {
+        foreach my $line (split("\n",$iostats)) {
+          my ($k, $v) = split(": ",$line);
+          if($self->{stats}{$k}) {
+            $self->{stats}{$k} += $v;
+          } else {
+            $self->{stats}{$k} = $v;
+          }
+        }
+      }
+
+      $kid->{gotstats} = 1;
+    }
+  }
+
+}
+
+sub run_with_stats {
+  my $h = IPC::Run::start(@_);
+  # IPC::Run::start is not a real constructor and can't deal with subclasses,
+  # but still returns an object, so do some monkey business here and re-bless
+  # into the subclass
+  bless($h, "Utils::MonitorRun");
+  $h->{stats} = {};
+  $h->{stats}{utime} = 0;
+  $h->{stats}{stime} = 0;
+
+  $h->dumpstats();
+  $h->finish();
+  return $h->{stats};
+}
+
+sub reap_nb {
+  my $self = shift;
+
+  $self->dumpstats();
+
+  return $self->SUPER::reap_nb;
+}
+
+1;


### PR DESCRIPTION
## Background

This pull request is about trying to collect metrics on how long various operations take as part of delivering content to end users, especially operations that involve filesystem use.

## Overview

The main parts here are:
* `Utils::MonitorRun` - wraps `IPC::Run` and tries to gather some statistics from subprocesses right before it exits. The referenced `catprocio` stuff is covered in this related PR: https://github.com/mlibrary/nebula/pull/679
* Directly record a metric in `Utils::Extract` (if given a place to record them) when extracting a file.
* Directly record a metric in `MdpItem` (if prometheus is available in the global context) when constructing an MdpItem (which may require reading the METS from disk)

## Reviewing

How to see it in action:

* Visit https://beta-1.babel.hathitrust.org/cgi/pt (for any volume or anything that loads images)
* Then check https://beta-1.babel.hathitrust.org/cgi/imgsrv/metrics - should see the numbers increasing
* Can also look at all available metrics via https://grafana.kubernetes.hathitrust.org/explore?schemaVersion=1&panes=%7B%22rbh%22:%7B%22datasource%22:%2220yiuKvnk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bjob%3D%5C%22imgsrv_beta_1%5C%22%7D%22,%22range%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%2220yiuKvnk%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1
* metrics to check - anything starting with `imgsrv_` or `utils_extract` - for example: `utils_extract_io_stats_read_bytes`, `imgsrv_srv_image_seconds_sum`

(note that the scraping looks weird because I think some of the prometheus requests are getting subject to throttling - that is something to figure out)

To consider: Should we take care of the TODO items in `Utils::Extract` now? If not, are they good candidates for tracking in github issues here?

This **shouldn't** break anything that uses these classes that isn't aware of the metrics stuff, but that's worth verifying.

@mwarin I included you as a reviewer since you have been working on metrics in ingest. More of the prometheus setup will be in the corresponding `imgsrv` pull request
@moseshll I included you as a reviewer since you have some experience with mdp-lib, and might be able to weigh in on the shenanigans in `Utils::MonitorRun`.

See also: https://github.com/mlibrary/nebula/pull/679, https://github.com/hathitrust/imgsrv/pull/21
